### PR TITLE
Add reset logic and test coverage

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -16,5 +16,6 @@ Scope:
     a. Progress bar
     b. Require in-order
     c. Silence on going backwards
-5. Maximum hunt size and relevant permissions
+5. Maximum hunt size (10 MB) and relevant permissions
 6. Redirect to options on install
+7. Clean up options page (squishy, make it a big welcome page with a tutorial)

--- a/src/__tests__/save_hunt.test.ts
+++ b/src/__tests__/save_hunt.test.ts
@@ -1,6 +1,7 @@
 import { sampleHunt } from "./create_hunt_config";
 import { buildProviderMocks } from "./build_mocks";
 import { saveConfigAndLaunch } from "../../src/options";
+import { resetStorage } from "../../src/providers/helpers";
 
 // TODO: Add additional logic and testing for reseting/clearing the hunt.
 // TODO: The options page needs frontend testing for all its different states.
@@ -35,4 +36,23 @@ it("Save config", () => {
   expect(saveMock).toBeCalledTimes(1);
   expect(createTabMock).toBeCalledTimes(1);
   expect(createTabMock).toBeCalledWith("beginning.html");
+});
+
+it("Reset config", () => {
+  // Avoid the call to setup the listeners themselves.
+  jest.resetAllMocks();
+
+  saveMock.mockImplementation((items, callback) => {
+    expect(items).toEqual({
+      sourceType: null,
+      huntConfig: null,
+      maxProgress: null,
+      currentProgress: null,
+    });
+    // Provide sample hunt, with no progress made yet
+    callback();
+  });
+
+  resetStorage(() => {});
+  expect(saveMock).toBeCalledTimes(1);
 });

--- a/src/background.ts
+++ b/src/background.ts
@@ -6,10 +6,11 @@ import { addMessageListener } from "./providers/runtime";
 import { loadStorageValues } from "./providers/storage";
 import { createTab } from "./providers/tabs";
 import { EMPTY_OR_INVALID_HUNT } from "./types/errors";
+import { nonNull } from "./utils/helpers";
 
 const openClueCallback = (items: any) => {
   // TODO: TYLER SHOULD WE OPEN THE OPTIONS PAGE WHEN THERES NO HUNT? OR A TUTORIAL?
-  if (items.huntConfig && items.huntConfig.clues && items.currentProgress !== undefined) {
+  if (items.huntConfig && items.huntConfig.clues && nonNull(items.currentProgress)) {
     if (items.currentProgress == 0) {
       return;
     }

--- a/src/components/CluePage.tsx
+++ b/src/components/CluePage.tsx
@@ -18,6 +18,7 @@ import { Encrypt } from "../utils/parse";
 // import { provider } from "../providers/chrome";
 import { theme } from "./theme";
 import { getURL } from "../providers/runtime";
+import { nonNull } from "../utils/helpers";
 
 export interface BeginningPageProps {
   title: React.ReactNode;
@@ -120,7 +121,7 @@ export const CluePage = (props: CluePageProps) => {
                         variant="outlined"
                         value={inputKey}
                         onChange={(e) => setInputKey(e.target.value.trim())}
-                        error={interactive === undefined || !solved}
+                        error={!nonNull(interactive) || !solved}
                       />
                       {/* TODO: ADD BETTER ERROR/RESPONSIVENESS SUPPORT (Show message on error) */}
                       <Button

--- a/src/content_script.tsx
+++ b/src/content_script.tsx
@@ -5,6 +5,7 @@ import { sendMessage } from "./providers/runtime";
 // import { provider } from "./providers/chrome";
 import { loadStorageValues, saveStorageValues } from "./providers/storage";
 import { ClueConfig, HuntConfig } from "./types/hunt_config";
+import { nonNull } from "./utils/helpers";
 import { Decrypt } from "./utils/parse";
 
 /**
@@ -91,7 +92,7 @@ const sendEmptyOrInvalidHunt = () => {
 const loadHuntCallback = (items: any) => {
   logger.info(items);
   try {
-    if (items.huntConfig && items.maxProgress !== undefined) {
+    if (items.huntConfig && nonNull(items.maxProgress)) {
       const urlMatchClue = checkHuntForURLMatch(items.huntConfig as HuntConfig);
       if (urlMatchClue) {
         sendClueFound(items.maxProgress, urlMatchClue);

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -30,6 +30,7 @@ import { saveStorageValues } from "./providers/storage";
 import { createTab } from "./providers/tabs";
 import { getLastError, getURL } from "./providers/runtime";
 import { Render } from "./utils/root";
+import { resetStorage } from "./providers/helpers";
 
 interface SourceFormType {
   sourceType: HuntSource;
@@ -111,6 +112,8 @@ const Options = () => {
     undefined
   );
   const [sampleModalOpen, setSampleModalOpen] = useState<boolean>(false);
+
+  const [hasReset, setHasReset] = useState<boolean>(false);
 
   const validateSubmitable = () => {
     if (validationError) {
@@ -216,8 +219,7 @@ const Options = () => {
     }
   };
   const onReset = () => {
-    // TODO: TYLER IMPLEMENT
-    logger.error("Reset functionality coming soon!");
+    resetStorage(() => setHasReset(true));
   };
 
   return (
@@ -371,8 +373,8 @@ const Options = () => {
                 >
                   Submit
                 </Button>
-                <Button variant="outlined" size="medium" onClick={onReset} color="secondary">
-                  Reset
+                <Button variant="outlined" size="medium" onClick={onReset} color="secondary" disabled={hasReset}>
+                  Clear Hunt
                 </Button>
               </Grid>
             </Grid>

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -9,6 +9,7 @@ import {
 import { DecryptClue } from "./utils/parse";
 import { loadStorageValues } from "./providers/storage";
 import { Render } from "./utils/root";
+import { nonNull } from "./utils/helpers";
 
 const DEFAULT_LOADING_CLUE = {
   id: -1,
@@ -25,7 +26,7 @@ const loadSolvedClueFromStorage = (
   errorCallback: any
 ) => {
   loadStorageValues(["huntConfig", "currentProgress"], (items: any) => {
-    if (!items.huntConfig || items.currentProgress === undefined) {
+    if (!items.huntConfig || !nonNull(items.currentProgress)) {
       errorCallback(EMPTY_OR_INVALID_HUNT);
       return;
     }

--- a/src/providers/helpers.ts
+++ b/src/providers/helpers.ts
@@ -1,0 +1,9 @@
+import { saveStorageValues } from "./storage";
+import { SaveStorageCallback, storageKeys, StorageSaveObject } from "./types";
+
+export const resetStorage = (callback: SaveStorageCallback) => {
+    return saveStorageValues(storageKeys.reduce((ret: StorageSaveObject, storageKey)=>{
+        ret[storageKey] = null;
+        return ret;
+    }, {}), callback);
+}

--- a/src/providers/storage.ts
+++ b/src/providers/storage.ts
@@ -1,17 +1,14 @@
 import { getProvider } from "./chrome";
+import { StorageKeys, LoadStorageCallback, StorageSaveObject, SaveStorageCallback } from "./types";
 
-export type LoadStorageCallback = (items: any) => void;
-
-export type SaveStorageCallback = () => void;
-
-export const loadStorageValue = (key: string, callback: LoadStorageCallback) => {
+export const loadStorageValue = (key: StorageKeys, callback: LoadStorageCallback) => {
     return getProvider().storage.local.get(key, callback);
 }
 
-export const loadStorageValues = (keys: string[], callback: LoadStorageCallback) => {
+export const loadStorageValues = (keys: StorageKeys[], callback: LoadStorageCallback) => {
     return getProvider().storage.local.get(keys, callback);
 }
 
-export const saveStorageValues = (values: Object, callback: SaveStorageCallback) => {
+export const saveStorageValues = (values: StorageSaveObject, callback: SaveStorageCallback) => {
     return getProvider().storage.local.set(values, callback);
 }

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,0 +1,11 @@
+export type LoadStorageCallback = (items: any) => void;
+
+export type SaveStorageCallback = () => void;
+
+// All storage values must be named here in order to ensure consistency across the extension.
+export const storageKeys = ["maxProgress", "currentProgress", "sourceType", "huntConfig"] as const;
+export type StorageKeys = typeof storageKeys[number];
+
+export type StorageSaveObject = {
+    [key in StorageKeys]?: any;
+};

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,0 +1,1 @@
+export const nonNull = (val: any) => val !== undefined && val !== null;

--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -9,6 +9,7 @@ import {
   XORFieldsError,
 } from "../types/errors";
 import { ClueConfig, HuntConfig } from "../types/hunt_config";
+import { nonNull } from "./helpers";
 
 export const DEFAULT_BACKGROUND =
   "https://images.unsplash.com/photo-1583425921686-c5daf5f49e4a?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1031&q=80";
@@ -18,7 +19,7 @@ const ValidateRequiredField = (
   fieldName: string,
   index?: number
 ) => {
-  if (value === undefined) {
+  if (!nonNull(value)) {
     throw new MissingFieldError(fieldName, index);
   }
   return value;
@@ -29,7 +30,7 @@ const ValidateRequiredNonEmptyField = (
   fieldName: string,
   index?: number
 ) => {
-  if (value === undefined) {
+  if (!nonNull(value)) {
     throw new MissingFieldError(fieldName, index);
   }
   if (value === "") {
@@ -54,7 +55,7 @@ const ValidateXORFields = (
 };
 
 const ValidateVersion = (value: any) => {
-  if (value === undefined) {
+  if (!nonNull(value)) {
     throw new MissingFieldError("version");
   } else if (!SUPPORTED_VERSIONS.includes(value)) {
     throw new UnsupportedVersionError(value);


### PR DESCRIPTION
Clicking the reset button in the options page will now clear the hunt. Also improves error validation throughout the hunt. We may want to provide improved error handling logic in the event of a malformed hunt that is loaded/becomes corrupt halfway through. This should suffice well enough for a "cancel/reset" mechanism for now, however.

Adds some additional helpers to achieve this and promote data fidelity.