### PR TITLE
Open options menu when extension is installed

### DIFF
--- a/src/__tests__/background.test.ts
+++ b/src/__tests__/background.test.ts
@@ -1,6 +1,7 @@
 import {
   setupMessageListener,
   setupOnClickedListener,
+  setupOnInstalledListener,
 } from "../../src/background";
 import { sampleHunt } from "./create_hunt_config";
 import { buildProviderMocks } from "./build_mocks";
@@ -14,6 +15,7 @@ jest.mock("../../src/logger/index");
 
 const {
   addMessageListenerMock,
+  addInstalledListenerMock,
   addOnClickedListenerMock,
   setBadgeMock,
   createTabMock,
@@ -106,5 +108,23 @@ it("Click malformed config", () => {
 
   expect(setBadgeMock).toBeCalledTimes(1);
   expect(setBadgeMock).toBeCalledWith("");
+  expect(createTabMock).not.toBeCalled();
+});
+
+it("Install and open tab", () => {
+  // Avoid the call to setup the listeners themselves.
+  // First install event
+  jest.resetAllMocks();
+  addInstalledListenerMock.mockImplementation((callback) => callback({reason: "install"}));
+
+  setupOnInstalledListener();
+  expect(createTabMock).toBeCalledTimes(1);
+  expect(createTabMock).toBeCalledWith("options.html");
+
+  // Update event
+  jest.resetAllMocks();
+  addInstalledListenerMock.mockImplementation((callback) => callback({reason: "update"}));
+
+  setupOnInstalledListener();
   expect(createTabMock).not.toBeCalled();
 });

--- a/src/__tests__/build_mocks.ts
+++ b/src/__tests__/build_mocks.ts
@@ -3,6 +3,7 @@ import {
   saveStorageValues,
 } from "../../src/providers/storage";
 import {
+  addInstalledListener,
   addMessageListener,
   getLastError,
   getURL,
@@ -16,6 +17,7 @@ import { createTab } from "../../src/providers/tabs";
 export const buildProviderMocks = () => ({
   alertMock: jest.mocked(alertWrapper),
   addMessageListenerMock: jest.mocked(addMessageListener),
+  addInstalledListenerMock: jest.mocked(addInstalledListener),
   addOnClickedListenerMock: jest.mocked(addOnClickedListener),
   createTabMock: jest.mocked(createTab),
   currentURLMock: jest.mocked(getCurrentURL),

--- a/src/background.ts
+++ b/src/background.ts
@@ -2,10 +2,12 @@
 
 import { logger } from "./logger";
 import { addOnClickedListener, setBadgeText } from "./providers/action";
-import { addMessageListener } from "./providers/runtime";
+import { addInstalledListener, addMessageListener } from "./providers/runtime";
 import { loadStorageValues } from "./providers/storage";
 import { createTab } from "./providers/tabs";
 import { EMPTY_OR_INVALID_HUNT } from "./types/errors";
+
+const CHROME_INSTALL_REASON = "install";
 
 const openClueCallback = (items: any) => {
   // TODO: TYLER SHOULD WE OPEN THE OPTIONS PAGE WHEN THERES NO HUNT? OR A TUTORIAL?
@@ -53,5 +55,15 @@ export const setupOnClickedListener = () =>
     loadStorageValues(["huntConfig", "currentProgress"], openClueCallback);
   });
 
+export const setupOnInstalledListener = () => {
+  addInstalledListener((details) => {
+    logger.debug(`Received install event ${details.reason}`);
+    if (details.reason === CHROME_INSTALL_REASON) {
+      createTab("options.html");
+    }
+  });
+};
+
+setupOnInstalledListener();
 setupMessageListener();
 setupOnClickedListener();

--- a/src/providers/runtime.ts
+++ b/src/providers/runtime.ts
@@ -2,8 +2,14 @@ import { getProvider } from "./chrome";
 
 export type OnMessageListenerCallback = (request: any, sender: any, sendResponse: any) => void;
 
+export type OnInstalledListenerCallback = (details: {reason: string}) => void;
+
 export const addMessageListener = (callback: OnMessageListenerCallback) => {
     return getProvider().runtime.onMessage.addListener(callback);
+}
+
+export const addInstalledListener = (callback: OnInstalledListenerCallback) => {
+    return getProvider().runtime.onInstalled.addListener(callback);
 }
 
 export const sendMessage = (message: Object) => {


### PR DESCRIPTION
Open the options menu when the extension is installed. Note that before this can land we'll need to rewrite the options page to fit an entire page, not just the popup. This may also benefit from an entire UX/training/tutorial flow.