### PR TITLE
Preview tooltip for encode clues

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,4 +139,5 @@ The following resources were used to create this extension. Thank You :)
 - [HTML Tables](<https://www.w3schools.com/jsref/met_tablerow_insertcell.asp#:~:text=Insert%20new%20row(s)%20at,cells%20in%20the%20new%20row.>)
 - [Chrome Extension Downloads](https://stackoverflow.com/questions/4845215/making-a-chrome-extension-download-a-file/24162238)
 - [Typescript Starter Setup](https://github.com/chibat/chrome-extension-typescript-starter/tree/master)
+- [YouTube Video Embedder](https://dev.to/bravemaster619/simplest-way-to-embed-a-youtube-video-in-your-react-app-3bk2)
 - Some images were created with the assistance of DALL·E 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "path-browserify": "^1.0.1",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
-        "react-youtube": "^10.1.0",
         "ts-node": "^10.9.1"
       },
       "devDependencies": {
@@ -5174,7 +5173,8 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/fast-glob": {
       "version": "3.3.0",
@@ -7211,11 +7211,6 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
-    "node_modules/load-script": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-      "integrity": "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA=="
-    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -8122,22 +8117,6 @@
         "react-dom": ">=16.6.0"
       }
     },
-    "node_modules/react-youtube": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/react-youtube/-/react-youtube-10.1.0.tgz",
-      "integrity": "sha512-ZfGtcVpk0SSZtWCSTYOQKhfx5/1cfyEW1JN/mugGNfAxT3rmVJeMbGpA9+e78yG21ls5nc/5uZJETE3cm3knBg==",
-      "dependencies": {
-        "fast-deep-equal": "3.1.3",
-        "prop-types": "15.8.1",
-        "youtube-player": "5.5.2"
-      },
-      "engines": {
-        "node": ">= 14.x"
-      },
-      "peerDependencies": {
-        "react": ">=0.14.1"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -8679,11 +8658,6 @@
       "engines": {
         "node": ">= 10"
       }
-    },
-    "node_modules/sister": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/sister/-/sister-3.0.2.tgz",
-      "integrity": "sha512-p19rtTs+NksBRKW9qn0UhZ8/TUI9BPw9lmtHny+Y3TinWlOa9jWh9xB0AtPSdmOy49NJJJSSe0Ey4C7h0TrcYA=="
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -10170,29 +10144,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/youtube-player": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/youtube-player/-/youtube-player-5.5.2.tgz",
-      "integrity": "sha512-ZGtsemSpXnDky2AUYWgxjaopgB+shFHgXVpiJFeNB5nWEugpW1KWYDaHKuLqh2b67r24GtP6HoSW5swvf0fFIQ==",
-      "dependencies": {
-        "debug": "^2.6.6",
-        "load-script": "^1.0.0",
-        "sister": "^3.0.0"
-      }
-    },
-    "node_modules/youtube-player/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/youtube-player/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "path-browserify": "^1.0.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-youtube": "^10.1.0",
     "ts-node": "^10.9.1"
   },
   "devDependencies": {

--- a/public/assets/encoder.css
+++ b/public/assets/encoder.css
@@ -9,3 +9,8 @@ body {
 .clue-list-item {
   background-color: #555;
 }
+
+.MuiTooltip-tooltipPlacementRight {
+  /* Avoid showing empty tooltip box because of rendered float clue preview */
+  background-color: transparent !important;
+}

--- a/public/assets/encoder.css
+++ b/public/assets/encoder.css
@@ -14,3 +14,19 @@ body {
   /* Avoid showing empty tooltip box because of rendered float clue preview */
   background-color: transparent !important;
 }
+
+.video-responsive {
+  overflow: hidden;
+  padding-bottom: 56.25%;
+  padding-top: 25%;
+  position: relative;
+  height: 0;
+}
+
+.video-responsive iframe {
+  left: 0;
+  top: 0;
+  height: 100%;
+  width: 100%;
+  position: absolute;
+}

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -19,6 +19,10 @@
       "js": ["js/content_script.js"]
     }
   ],
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'; script-src-elem 'self' 'unsafe-inline' https://www.youtube.com/iframe_api;",
+    "sandbox": "sandbox allow-scripts allow-forms allow-popups allow-modals; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.youtube.com/iframe_api; child-src 'self';"
+  },
   "action": {
     "default_title": "Scavenger Hunt",
     "default_icon": "graphics/scav.png"

--- a/src/beginning.tsx
+++ b/src/beginning.tsx
@@ -16,6 +16,7 @@ const Beginning = () => {
   const [beginningText, setBeginningText] = useState<string>(
     "Empty beginning text. Please reset the hunt.",
   );
+  const [backgroundURL, setBackgroundURL] = useState<string>("");
 
   useEffect(
     () =>
@@ -23,13 +24,7 @@ const Beginning = () => {
         if (items.huntConfig) {
           const { background, beginning, name } = items.huntConfig;
           // Set background image
-          const sheet = document.styleSheets[4];
-          sheet.insertRule(
-            "body { background: url('" +
-              background +
-              "') no-repeat center; background-size: cover; background-position: cover;}",
-            0,
-          );
+          setBackgroundURL(background);
           // Set beginning text
           setBeginningText(beginning);
           setHuntName(name);
@@ -40,7 +35,13 @@ const Beginning = () => {
     [],
   );
 
-  return <BeginningPage title={huntName} message={beginningText} />;
+  return (
+    <BeginningPage
+      title={huntName}
+      message={beginningText}
+      backgroundURL={backgroundURL}
+    />
+  );
 };
 
 Render(<Beginning />);

--- a/src/components/BackgroundWrapper.tsx
+++ b/src/components/BackgroundWrapper.tsx
@@ -1,0 +1,29 @@
+import React, { PropsWithChildren } from "react";
+
+export interface BackgroundProps {
+  backgroundURL: string;
+  scale?: string;
+}
+// TODO: TYLER MAKE SURE BACKGROUNDURL IS ALWAYS SANITIZED
+
+export const BackgroundWrapper = (
+  props: PropsWithChildren<BackgroundProps>,
+) => (
+  <div
+    style={{
+      width: "100%",
+      minWidth: `${props.scale ?? "100"}vw`,
+      height: "100%",
+      minHeight: `${props.scale ?? "100"}vh`,
+      maxHeight: props.scale ? `${props.scale}vh` : undefined,
+      float: "left",
+      margin: "0px",
+      backgroundImage: `url("${props.backgroundURL}")`,
+      backgroundSize: "cover",
+      backgroundRepeat: "repeat-y",
+      backgroundPosition: "center center",
+    }}
+  >
+    {props.children}
+  </div>
+);

--- a/src/components/CluePage.tsx
+++ b/src/components/CluePage.tsx
@@ -6,6 +6,7 @@ import {
   Container,
   FormControl,
   Grid,
+  styled,
   TextField,
   Typography,
 } from "@mui/material";
@@ -56,6 +57,14 @@ export const CluePage = (props: CluePageProps) => {
     ? { transform: "scale(0.5, 0.5)", "-webkit-transform-origin-y": "top" }
     : {};
   const previewScale = previewOnly ? "30" : undefined;
+  const previewButtonStyles = previewOnly
+    ? {
+        "&.Mui-disabled": {
+          color: "#fdd835",
+        },
+      }
+    : {};
+  const StyledButton = styled(Button)(previewButtonStyles);
 
   // It will take a second to load, so assume not solved until we know for sure the value of interactive
   useEffect(() => {
@@ -139,13 +148,15 @@ export const CluePage = (props: CluePageProps) => {
                           error={!nonNull(interactive) || !solved}
                         />
                         {/* TODO: ADD BETTER ERROR/RESPONSIVENESS SUPPORT (Show message on error) */}
-                        <Button
+                        <StyledButton
                           variant="outlined"
                           size="medium"
+                          color="primary"
                           onClick={validateKey}
+                          disabled={previewOnly || solved}
                         >
                           Submit
-                        </Button>
+                        </StyledButton>
                       </FormControl>
                     )}
                   </CardContent>

--- a/src/components/CluePage.tsx
+++ b/src/components/CluePage.tsx
@@ -10,6 +10,7 @@ import {
   Typography,
 } from "@mui/material";
 import React, { useEffect, useState } from "react";
+import { BackgroundWrapper } from "src/components/BackgroundWrapper";
 import { PageHeaderAndSubtitle } from "src/components/PageHeaderAndSubtitle";
 import { theme } from "src/components/theme";
 import { getURL } from "src/providers/runtime";
@@ -22,6 +23,7 @@ import { Footer } from "./Footer";
 export interface BeginningPageProps {
   title: React.ReactNode;
   message: React.ReactNode;
+  backgroundURL: string;
 }
 
 export interface CluePageProps {
@@ -29,15 +31,18 @@ export interface CluePageProps {
   encrypted: boolean;
   clue: ClueConfig;
   error?: string;
+  previewOnly?: boolean;
+  backgroundURL: string;
 }
 
 export const CluePage = (props: CluePageProps) => {
-  // TODO: TYLER FIGURE OUT THEMES
   const {
     huntName,
     encrypted,
     clue: { id, text, image, alt, interactive },
     error,
+    previewOnly,
+    backgroundURL,
   } = props;
   const imageURL = image && !image.startsWith("http") ? getURL(image) : image;
 
@@ -46,6 +51,11 @@ export const CluePage = (props: CluePageProps) => {
 
   const [inputKey, setInputKey] = useState<string>("");
   const [solved, setSolved] = useState<boolean>(false);
+
+  const previewStyles = previewOnly
+    ? { transform: "scale(0.5, 0.5)", "-webkit-transform-origin-y": "top" }
+    : {};
+  const previewScale = previewOnly ? "30" : undefined;
 
   // It will take a second to load, so assume not solved until we know for sure the value of interactive
   useEffect(() => {
@@ -75,6 +85,86 @@ export const CluePage = (props: CluePageProps) => {
 
   return (
     <>
+      <BackgroundWrapper backgroundURL={backgroundURL} scale={previewScale}>
+        <ThemeProvider theme={theme}>
+          <Container
+            maxWidth="sm"
+            sx={{ mt: 3, "&::after": { flex: "auto" }, ...previewStyles }}
+          >
+            <Grid
+              container
+              spacing={2}
+              justifyContent="center"
+              alignItems="center"
+            >
+              <Grid item xs={12}>
+                <Card sx={{ mt: 4, backgroundColor: "#333" }}>
+                  <CardContent>
+                    <PageHeaderAndSubtitle header={title} />
+                    {solved && (
+                      <Typography
+                        variant="body1"
+                        textAlign="center"
+                        color="white"
+                        mt={1}
+                      >
+                        {/* TODO: TYLER DO LINE REPLACEMENT */}
+                        {error ?? text}
+                      </Typography>
+                    )}
+                    {image && (
+                      <img
+                        src={imageURL}
+                        alt={alt}
+                        loading="lazy"
+                        width="75%"
+                        height="75%"
+                        style={{
+                          marginLeft: "auto",
+                          marginRight: "auto",
+                          display: "block",
+                        }}
+                      />
+                    )}
+                    {interactive && (
+                      // TODO: ADD STYLING
+                      <FormControl sx={{ minWidth: "100%" }}>
+                        {interactive.prompt && (
+                          <Typography>{interactive.prompt}</Typography>
+                        )}
+                        <TextField
+                          variant="outlined"
+                          value={inputKey}
+                          onChange={(e) => setInputKey(e.target.value.trim())}
+                          error={!nonNull(interactive) || !solved}
+                        />
+                        {/* TODO: ADD BETTER ERROR/RESPONSIVENESS SUPPORT (Show message on error) */}
+                        <Button
+                          variant="outlined"
+                          size="medium"
+                          onClick={validateKey}
+                        >
+                          Submit
+                        </Button>
+                      </FormControl>
+                    )}
+                  </CardContent>
+                </Card>
+              </Grid>
+              <Grid item xs={12}></Grid>
+              {!previewOnly && <Footer />}
+            </Grid>
+          </Container>
+        </ThemeProvider>
+      </BackgroundWrapper>
+    </>
+  );
+};
+
+// TODO: TYLER REFACTOR TO MAKE THESE COMMON
+export const BeginningPage = (props: BeginningPageProps) => (
+  <>
+    <BackgroundWrapper backgroundURL={props.backgroundURL}>
       <ThemeProvider theme={theme}>
         <Container maxWidth="sm" sx={{ mt: 3, "&::after": { flex: "auto" } }}>
           <Grid
@@ -86,54 +176,16 @@ export const CluePage = (props: CluePageProps) => {
             <Grid item xs={12}>
               <Card sx={{ mt: 4, backgroundColor: "#333" }}>
                 <CardContent>
-                  <PageHeaderAndSubtitle header={title} />
-                  {solved && (
-                    <Typography
-                      variant="body1"
-                      textAlign="center"
-                      color="white"
-                      mt={1}
-                    >
-                      {/* TODO: TYLER DO LINE REPLACEMENT */}
-                      {error ?? text}
-                    </Typography>
-                  )}
-                  {image && (
-                    <img
-                      src={imageURL}
-                      alt={alt}
-                      loading="lazy"
-                      width="75%"
-                      height="75%"
-                      style={{
-                        marginLeft: "auto",
-                        marginRight: "auto",
-                        display: "block",
-                      }}
-                    />
-                  )}
-                  {interactive && (
-                    // TODO: ADD STYLING
-                    <FormControl sx={{ minWidth: "100%" }}>
-                      {interactive.prompt && (
-                        <Typography>{interactive.prompt}</Typography>
-                      )}
-                      <TextField
-                        variant="outlined"
-                        value={inputKey}
-                        onChange={(e) => setInputKey(e.target.value.trim())}
-                        error={!nonNull(interactive) || !solved}
-                      />
-                      {/* TODO: ADD BETTER ERROR/RESPONSIVENESS SUPPORT (Show message on error) */}
-                      <Button
-                        variant="outlined"
-                        size="medium"
-                        onClick={validateKey}
-                      >
-                        Submit
-                      </Button>
-                    </FormControl>
-                  )}
+                  <PageHeaderAndSubtitle header={props.title} />
+                  <Typography
+                    variant="body1"
+                    textAlign="center"
+                    color="white"
+                    mt={1}
+                  >
+                    {/* TODO: TYLER DO LINE REPLACEMENT */}
+                    {props.message}
+                  </Typography>
                 </CardContent>
               </Card>
             </Grid>
@@ -143,37 +195,6 @@ export const CluePage = (props: CluePageProps) => {
           </Grid>
         </Container>
       </ThemeProvider>
-    </>
-  );
-};
-
-// TODO: TYLER REFACTOR TO MAKE THESE COMMON
-export const BeginningPage = (props: BeginningPageProps) => (
-  <>
-    <ThemeProvider theme={theme}>
-      <Container maxWidth="sm" sx={{ mt: 3, "&::after": { flex: "auto" } }}>
-        <Grid container spacing={2} justifyContent="center" alignItems="center">
-          <Grid item xs={12}>
-            <Card sx={{ mt: 4, backgroundColor: "#333" }}>
-              <CardContent>
-                <PageHeaderAndSubtitle header={props.title} />
-                <Typography
-                  variant="body1"
-                  textAlign="center"
-                  color="white"
-                  mt={1}
-                >
-                  {/* TODO: TYLER DO LINE REPLACEMENT */}
-                  {props.message}
-                </Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-          <Grid item xs={12}>
-            <Footer />
-          </Grid>
-        </Grid>
-      </Container>
-    </ThemeProvider>
+    </BackgroundWrapper>
   </>
 );

--- a/src/components/CluePage.tsx
+++ b/src/components/CluePage.tsx
@@ -54,7 +54,7 @@ export const CluePage = (props: CluePageProps) => {
   const [solved, setSolved] = useState<boolean>(false);
 
   const previewStyles = previewOnly
-    ? { transform: "scale(0.5, 0.5)", "-webkit-transform-origin-y": "top" }
+    ? { transform: "scale(0.5, 0.5)", WebkitTransformOriginY: "top" }
     : {};
   const previewScale = previewOnly ? "30" : undefined;
   const previewButtonStyles = previewOnly

--- a/src/components/landing_page/Tutorial.tsx
+++ b/src/components/landing_page/Tutorial.tsx
@@ -14,6 +14,7 @@ export const Tutorial = () => (
           <Typography textAlign={"center"}>
             Follow the clues, visit the matching websites, and solve the hunt!
           </Typography>
+          {/* TODO: TYLER FIX THE CSP ERROR FOR YOUTUBE IFRAME */}
           <YouTube videoId="yBkaL08VXWs" style={{ display: "flex" }} />
         </Grid>
       </Grid>

--- a/src/components/landing_page/Tutorial.tsx
+++ b/src/components/landing_page/Tutorial.tsx
@@ -1,6 +1,5 @@
 import { Container, Grid, Typography } from "@mui/material";
 import React from "react";
-import YouTube from "react-youtube";
 import { PageHeaderAndSubtitle } from "src/components/PageHeaderAndSubtitle";
 
 export const Tutorial = () => (
@@ -14,8 +13,17 @@ export const Tutorial = () => (
           <Typography textAlign={"center"}>
             Follow the clues, visit the matching websites, and solve the hunt!
           </Typography>
-          {/* TODO: TYLER FIX THE CSP ERROR FOR YOUTUBE IFRAME */}
-          <YouTube videoId="yBkaL08VXWs" style={{ display: "flex" }} />
+          {/* YouTube embedder based on https://dev.to/bravemaster619/simplest-way-to-embed-a-youtube-video-in-your-react-app-3bk2 */}
+          <div className="video-responsive">
+            <iframe
+              width="853"
+              height="480"
+              src={`https://www.youtube.com/embed/yBkaL08VXWs`}
+              allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+              title="Embedded youtube"
+            />
+          </div>
         </Grid>
       </Grid>
     </Container>

--- a/src/components/theme.ts
+++ b/src/components/theme.ts
@@ -2,12 +2,12 @@ import { createTheme } from "@mui/material";
 
 export const theme = createTheme({
   palette: {
-    secondary: {
-      main: "#7646f3",
-    },
     primary: {
       main: "#fdd835",
       contrastText: "rgba(0,0,0,0.95)",
+    },
+    secondary: {
+      main: "#7646f3",
     },
     text: {
       primary: "rgba(255,255,255,0.87)",

--- a/src/encode.tsx
+++ b/src/encode.tsx
@@ -358,7 +358,11 @@ const Encode = () => {
                                 title={
                                   <CluePage
                                     key={"preview" + id}
-                                    huntName={"Preview"}
+                                    huntName={
+                                      huntConfig.name.length
+                                        ? huntConfig.name
+                                        : "Preview"
+                                    }
                                     encrypted={false}
                                     clue={{
                                       id,

--- a/src/encode.tsx
+++ b/src/encode.tsx
@@ -359,11 +359,7 @@ const Encode = () => {
                                 title={
                                   <CluePage
                                     key={"preview" + id}
-                                    huntName={
-                                      huntConfig.name.length
-                                        ? huntConfig.name
-                                        : "Preview"
-                                    }
+                                    huntName={huntConfig.name || "Preview"}
                                     encrypted={false}
                                     clue={{
                                       id,
@@ -375,9 +371,8 @@ const Encode = () => {
                                     }}
                                     previewOnly={true}
                                     backgroundURL={
-                                      huntConfig.background.length
-                                        ? huntConfig.background
-                                        : getURL("graphics/background.png")
+                                      huntConfig.background ||
+                                      getURL("graphics/background.png")
                                     }
                                   />
                                 }

--- a/src/encode.tsx
+++ b/src/encode.tsx
@@ -27,6 +27,7 @@ import {
   Tooltip,
 } from "@mui/material";
 import React, { ChangeEvent, useEffect, useState } from "react";
+import { CluePage } from "src/components/CluePage";
 import { ExitableModal } from "src/components/ExitableModal";
 import { Footer } from "src/components/Footer";
 import { PageHeaderAndSubtitle } from "src/components/PageHeaderAndSubtitle";
@@ -351,116 +352,142 @@ const Encode = () => {
                               { id, url, text, image, alt, interactive },
                               index,
                             ) => (
-                              <ListItem
-                                key={id}
-                                className="clue-list-item"
-                                divider
-                              >
-                                {huntConfig.clues.length > 1 && (
-                                  <>
-                                    <IconButton
-                                      edge="start"
-                                      aria-label="move up"
-                                      disabled={index === 0}
-                                      onClick={() => {
-                                        const currClues = [...huntConfig.clues];
-                                        const temp = {
-                                          ...currClues[index],
-                                          id: index,
-                                        };
-                                        currClues[index] = {
-                                          ...currClues[index - 1],
-                                          id: index + 1,
-                                        };
-
-                                        currClues[index - 1] = temp;
-
-                                        setHuntConfig({
-                                          ...huntConfig,
-                                          clues: currClues,
-                                        });
-                                      }}
-                                    >
-                                      <ArrowUpwardIcon />
-                                    </IconButton>
-
-                                    <IconButton
-                                      edge="start"
-                                      aria-label="move down"
-                                      disabled={
-                                        index === huntConfig.clues.length - 1
-                                      }
-                                      onClick={() => {
-                                        const currClues = [...huntConfig.clues];
-                                        const temp = {
-                                          ...currClues[index],
-                                          id: index + 2,
-                                        };
-                                        currClues[index] = {
-                                          ...currClues[index + 1],
-                                          id: index + 1,
-                                        };
-                                        currClues[index + 1] = temp;
-
-                                        setHuntConfig({
-                                          ...huntConfig,
-                                          clues: currClues,
-                                        });
-                                      }}
-                                    >
-                                      <ArrowDownwardIcon />
-                                    </IconButton>
-                                  </>
-                                )}
-
-                                <ListItemText
-                                  primary={`Clue ${index + 1}: ${text}`}
-                                  secondary={`URL: ${url}`}
-                                />
-                                <IconButton
-                                  edge="end"
-                                  aria-label="edit"
-                                  onClick={() => {
-                                    setCreatedClueIndex(index);
-                                    setCreatedClue({
+                              <Tooltip
+                                key={"tooltip" + id}
+                                placement="right"
+                                title={
+                                  <CluePage
+                                    key={"preview" + id}
+                                    huntName={"Preview"}
+                                    encrypted={false}
+                                    clue={{
                                       id,
                                       url,
                                       text,
                                       image,
                                       alt,
                                       interactive,
-                                    });
-                                    setCreateClueOpen(true);
-                                    setCreatedClueError(undefined);
-                                  }}
+                                    }}
+                                    previewOnly={true}
+                                    backgroundURL={huntConfig.background}
+                                  />
+                                }
+                              >
+                                <ListItem
+                                  key={id}
+                                  className="clue-list-item"
+                                  divider
                                 >
-                                  <EditIcon />
-                                </IconButton>
-                                <IconButton
-                                  edge="end"
-                                  aria-label="delete"
-                                  onClick={() => {
-                                    // Remove the clue from the list
-                                    const currClues = [...huntConfig.clues];
-                                    currClues.splice(index, 1);
+                                  {huntConfig.clues.length > 1 && (
+                                    <>
+                                      <IconButton
+                                        edge="start"
+                                        aria-label="move up"
+                                        disabled={index === 0}
+                                        onClick={() => {
+                                          const currClues = [
+                                            ...huntConfig.clues,
+                                          ];
+                                          const temp = {
+                                            ...currClues[index],
+                                            id: index,
+                                          };
+                                          currClues[index] = {
+                                            ...currClues[index - 1],
+                                            id: index + 1,
+                                          };
 
-                                    for (
-                                      let i = index;
-                                      i < currClues.length;
-                                      i++
-                                    ) {
-                                      currClues[i].id = i + 1;
-                                    }
+                                          currClues[index - 1] = temp;
 
-                                    setHuntConfig({
-                                      ...huntConfig,
-                                      clues: currClues,
-                                    });
-                                  }}
-                                >
-                                  <DeleteIcon />
-                                </IconButton>
-                              </ListItem>
+                                          setHuntConfig({
+                                            ...huntConfig,
+                                            clues: currClues,
+                                          });
+                                        }}
+                                      >
+                                        <ArrowUpwardIcon />
+                                      </IconButton>
+
+                                      <IconButton
+                                        edge="start"
+                                        aria-label="move down"
+                                        disabled={
+                                          index === huntConfig.clues.length - 1
+                                        }
+                                        onClick={() => {
+                                          const currClues = [
+                                            ...huntConfig.clues,
+                                          ];
+                                          const temp = {
+                                            ...currClues[index],
+                                            id: index + 2,
+                                          };
+                                          currClues[index] = {
+                                            ...currClues[index + 1],
+                                            id: index + 1,
+                                          };
+                                          currClues[index + 1] = temp;
+
+                                          setHuntConfig({
+                                            ...huntConfig,
+                                            clues: currClues,
+                                          });
+                                        }}
+                                      >
+                                        <ArrowDownwardIcon />
+                                      </IconButton>
+                                    </>
+                                  )}
+
+                                  <ListItemText
+                                    primary={`Clue ${index + 1}: ${text}`}
+                                    secondary={`URL: ${url}`}
+                                  />
+                                  <IconButton
+                                    edge="end"
+                                    aria-label="edit"
+                                    onClick={() => {
+                                      setCreatedClueIndex(index);
+                                      setCreatedClue({
+                                        id,
+                                        url,
+                                        text,
+                                        image,
+                                        alt,
+                                        interactive,
+                                      });
+                                      setCreateClueOpen(true);
+                                      setCreatedClueError(undefined);
+                                    }}
+                                  >
+                                    <EditIcon />
+                                  </IconButton>
+                                  <IconButton
+                                    edge="end"
+                                    aria-label="delete"
+                                    onClick={() => {
+                                      // Remove the clue from the list
+                                      const currClues = [...huntConfig.clues];
+                                      currClues.splice(index, 1);
+
+                                      for (
+                                        let i = index;
+                                        i < currClues.length;
+                                        i++
+                                      ) {
+                                        currClues[i].id = i + 1;
+                                      }
+
+                                      setHuntConfig({
+                                        ...huntConfig,
+                                        clues: currClues,
+                                      });
+                                    }}
+                                  >
+                                    <DeleteIcon />
+                                  </IconButton>
+                                </ListItem>
+                              </Tooltip>
                             ),
                           )}
                         </List>

--- a/src/encode.tsx
+++ b/src/encode.tsx
@@ -33,6 +33,7 @@ import { Footer } from "src/components/Footer";
 import { PageHeaderAndSubtitle } from "src/components/PageHeaderAndSubtitle";
 import { theme } from "src/components/theme";
 import { download } from "src/providers/downloads";
+import { getURL } from "src/providers/runtime";
 import {
   ClueConfig,
   HuntConfig,
@@ -373,7 +374,11 @@ const Encode = () => {
                                       interactive,
                                     }}
                                     previewOnly={true}
-                                    backgroundURL={huntConfig.background}
+                                    backgroundURL={
+                                      huntConfig.background.length
+                                        ? huntConfig.background
+                                        : getURL("graphics/background.png")
+                                    }
                                   />
                                 }
                               >

--- a/src/landing_page.tsx
+++ b/src/landing_page.tsx
@@ -59,7 +59,7 @@ export const LandingPage = () => (
             </Card>
           </Grid>
 
-          <Grid item xs={6}>
+          <Grid item xs={6} sx={{ display: "flex" }}>
             <Card sx={{ mt: 4, backgroundColor: "#383d5bdd" }}>
               <CardContent>
                 <Tutorial />

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -59,17 +59,7 @@ const Popup = () => {
   const [decryptedClue, setDecryptedClue] =
     useState<ClueConfig>(DEFAULT_LOADING_CLUE);
   const [error, setError] = useState<string | undefined>();
-
-  // TODO: TYLER MAKE THIS MORE REACT-IVE
-  const backgroundCallback = (background: string) => {
-    const sheet = document.styleSheets[5];
-    sheet.insertRule(
-      "body { background: url('" +
-        background +
-        "') no-repeat center; background-size: cover; background-position: cover;}",
-      0,
-    );
-  };
+  const [backgroundURL, setBackgroundURL] = useState<string>("");
 
   // TODO: TYLER MAKE SURE EVERYWHERE ELSE HAS THE USE EFFECT IT NEEDS
   useEffect(
@@ -77,7 +67,7 @@ const Popup = () => {
       loadSolvedClueFromStorage(
         setHuntName,
         setEncrypted,
-        backgroundCallback,
+        setBackgroundURL,
         setDecryptedClue,
         setError,
       ),
@@ -89,6 +79,7 @@ const Popup = () => {
       encrypted={encrypted}
       clue={decryptedClue}
       error={error}
+      backgroundURL={backgroundURL}
     />
   );
 };

--- a/src/providers/__mocks__/chrome.ts
+++ b/src/providers/__mocks__/chrome.ts
@@ -43,7 +43,8 @@ const storageGetter = (items: string | string[], callback: Function) => {
     ],
   };
 
-  const defaultCurrentProgress = 1;
+  // Change this to change which clue is rendered when visiting popup
+  const defaultCurrentProgress = 2;
 
   const defaultMaxProgress = 2;
 


### PR DESCRIPTION
Adds a preview tooltip on hover for the encode page. Clues will hover and view a preview of the beginning page. Eventually we should add a similar version of this in the create clue modal.

Also cleanups setting the background URL by just using a div wrapper around the contents. Need to do more testing with an actual build with that and make sure scrolling works when we have large popup contents.

Also fixed a bug where the YouTube player does not work due to content security policy issues.