### PR TITLE
Better create clue preview and other cleanup

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -12,5 +12,3 @@ Scope:
     c. Silence on going backwards
 3. Maximum hunt size (10 MB) and relevant permissions
 4. Update Readme and record new tutorial video
-5. Fix required fields having weird formatted *
-6. On last clue, button to reset hunt (or just in footer)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "scavenger-hunt-chrome-extension",
-  "version": "0.9.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scavenger-hunt-chrome-extension",
-      "version": "0.9.1",
+      "version": "1.0.0",
       "bundleDependencies": [
         "scavenger-hunt-chrome-extension"
       ],
-      "license": "MIT",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@emotion/react": "^11.10.6",
         "@emotion/styled": "^11.10.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scavenger-hunt-chrome-extension",
-  "version": "0.9.1",
+  "version": "1.0.0",
   "private": true,
   "description": "Create and Run Chrome Extension Scavenger Hunts",
   "repository": {

--- a/public/beginning.html
+++ b/public/beginning.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <meta charset="utf-8" />
     <title>Scavenger Hunt Beginning</title>
     <link
       rel="canonical"

--- a/public/encode.html
+++ b/public/encode.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <meta charset="utf-8" />
     <title>Scavenger Hunt Create</title>
     <link
       rel="canonical"

--- a/public/landing_page.html
+++ b/public/landing_page.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <meta charset="utf-8" />
     <title>Scavenger Hunt Home</title>
     <link
       rel="canonical"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Scavenger Hunt",
   "description": "A simple scavenger hunt extension based on URLs",
-  "version": "0.9.1",
+  "version": "1.0.0",
   "manifest_version": 3,
   "options_ui": {
     "page": "landing_page.html",

--- a/src/components/encode/CreateClueModal.tsx
+++ b/src/components/encode/CreateClueModal.tsx
@@ -6,13 +6,17 @@ import {
   TextField,
 } from "@mui/material";
 import React, { useEffect, useState } from "react";
+import { CluePage } from "src/components/reusable/CluePage";
 import { ExitableModal } from "src/components/reusable/ExitableModal";
+import { getURL } from "src/providers/runtime";
 import { ClueConfig, IntractiveConfig } from "src/types/hunt_config";
 import { ParseClue } from "src/utils/parse";
 
 export interface CreateClueModalProps {
   isOpen: boolean;
   createdClue: ClueConfig;
+  huntName: string;
+  huntBackground: string;
   setCreatedClue: (clue: ClueConfig) => void;
   onSave: (clue: ClueConfig) => void;
   onClose: () => void;
@@ -202,7 +206,7 @@ export const CreateClueModal = (props: CreateClueModalProps) => {
         <Button
           variant="contained"
           color="primary"
-          sx={{ mt: 2 }}
+          sx={{ mt: 2, mb: 2 }}
           onClick={() => {
             try {
               // Validate the clue and check for errors
@@ -220,6 +224,16 @@ export const CreateClueModal = (props: CreateClueModalProps) => {
         </Button>
         {createdClueError && <Alert severity="error">{createdClueError}</Alert>}
       </FormControl>
+      <CluePage
+        key={"preview clue creation"}
+        huntName={props.huntName || "Preview"}
+        encrypted={false}
+        clue={createdClue}
+        previewOnly={true}
+        backgroundURL={
+          props.huntBackground || getURL("graphics/background.png")
+        }
+      />
     </ExitableModal>
   );
 };

--- a/src/components/reusable/Footer.tsx
+++ b/src/components/reusable/Footer.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Divider, Link, Stack, Typography } from "@mui/material";
+import { Box, Divider, Link, Stack, Typography } from "@mui/material";
 import { yellow } from "@mui/material/colors";
 import React from "react";
 import { logger } from "src/logger";

--- a/src/components/reusable/Footer.tsx
+++ b/src/components/reusable/Footer.tsx
@@ -12,7 +12,7 @@ export const Footer = () => (
         sx={{
           width: "100%",
           height: "auto",
-          backgroundColor: "#989898d0",
+          backgroundColor: "#484848d0",
           paddingTop: "1rem",
           paddingBottom: "1rem",
           position: "fixed",
@@ -45,7 +45,6 @@ export const Footer = () => (
             variant="body1"
             textAlign="center"
             role="button"
-            color={yellow[600]}
             onClick={() => {
               const confirmBox = window.confirm(
                 "Do you really want to reset your progress?",
@@ -55,9 +54,8 @@ export const Footer = () => (
                 resetStorage(() => logger.info("Finished removing hunt"));
               }
             }}
-            sx={{ textDecoration: "underline" }}
           >
-            Reset Hunt
+            <Link color={yellow[600]}>Reset Hunt</Link>
           </Typography>
         </Stack>
       </Box>

--- a/src/components/reusable/Footer.tsx
+++ b/src/components/reusable/Footer.tsx
@@ -1,6 +1,9 @@
-import { Box, Link, Typography } from "@mui/material";
+import { Box, Button, Divider, Link, Stack, Typography } from "@mui/material";
 import { yellow } from "@mui/material/colors";
 import React from "react";
+import { logger } from "src/logger";
+import { resetStorage } from "src/providers/helpers";
+import { getURL } from "src/providers/runtime";
 
 export const Footer = () => (
   <>
@@ -9,7 +12,7 @@ export const Footer = () => (
         sx={{
           width: "100%",
           height: "auto",
-          backgroundColor: "#a8a8a850",
+          backgroundColor: "#989898d0",
           paddingTop: "1rem",
           paddingBottom: "1rem",
           position: "fixed",
@@ -17,15 +20,46 @@ export const Footer = () => (
           left: "0",
         }}
       >
-        <Typography variant="body1" textAlign="center">
-          {/* TODO: TYLER ADD OTHER LINKS AND THINGS */}
-          <Link
-            href="https://github.com/TylerJang27/Scav_Hunt_Extension"
+        <Stack
+          direction="row"
+          spacing={2}
+          divider={<Divider orientation="vertical" flexItem />}
+          sx={{ justifyContent: "center" }}
+        >
+          <Typography variant="body1" textAlign="center">
+            {/* TODO: TYLER ADD OTHER LINKS AND THINGS */}
+            <Link href={getURL("landing_page.html")} color={yellow[600]}>
+              Home
+            </Link>
+          </Typography>
+          <Typography variant="body1" textAlign="center">
+            {/* TODO: TYLER ADD OTHER LINKS AND THINGS */}
+            <Link
+              href="https://github.com/TylerJang27/Scav_Hunt_Extension"
+              color={yellow[600]}
+            >
+              GitHub
+            </Link>
+          </Typography>
+          <Typography
+            variant="body1"
+            textAlign="center"
+            role="button"
             color={yellow[600]}
+            onClick={() => {
+              const confirmBox = window.confirm(
+                "Do you really want to reset your progress?",
+              );
+              if (confirmBox === true) {
+                logger.info("Resetting hunt");
+                resetStorage(() => logger.info("Finished removing hunt"));
+              }
+            }}
+            sx={{ textDecoration: "underline" }}
           >
-            Scavenger Hunt Extension
-          </Link>
-        </Typography>
+            Reset Hunt
+          </Typography>
+        </Stack>
       </Box>
     </footer>
   </>

--- a/src/encode.tsx
+++ b/src/encode.tsx
@@ -527,6 +527,8 @@ const Encode = () => {
       <CreateClueModal
         isOpen={createClueOpen}
         createdClue={createdClue}
+        huntName={huntConfig.name}
+        huntBackground={huntConfig.background}
         setCreatedClue={setCreatedClue}
         onSave={onCreatedClueSave}
         onClose={onCreatedClueClose}


### PR DESCRIPTION
- Add a preview to the create clue modal (at the bottom)
- Fix utf-8 encoding on encode page for required text fields
- Bump manifest.json and package.json versions to 1.0.0
- Add more links to the footer, including a link to the home/landing page and a link/button to reset the hunt (includes a confirm popup)