### PR TITLE
Initialize Choose Hunt to Saved State

### DIFF
--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -6,3 +6,4 @@
 plugins
 user_trunk.yaml
 user.yaml
+tmp

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,26 +1,26 @@
 version: 0.1
 cli:
-  version: 1.16.2
+  version: 1.20.1
 plugins:
   sources:
     - id: trunk
-      ref: v1.2.5
+      ref: v1.4.4
       uri: https://github.com/trunk-io/plugins
 lint:
   enabled:
-    - actionlint@1.6.26
-    - checkov@2.5.6
-    - eslint@8.51.0
+    - actionlint@1.6.27
+    - checkov@3.2.31
+    - eslint@8.57.0
     - git-diff-check
-    - gitleaks@8.18.0
-    - markdownlint@0.37.0
-    - osv-scanner@1.4.1
-    - oxipng@8.0.0
-    - prettier@3.0.3
-    - sort-package-json@2.6.0
-    - trivy@0.45.1
-    - trufflehog@3.59.0
-    - yamllint@1.32.0
+    - gitleaks@8.18.2
+    - markdownlint@0.39.0
+    - osv-scanner@1.6.2
+    - oxipng@9.0.0
+    - prettier@3.2.5
+    - sort-package-json@2.8.0
+    - trivy@0.49.1
+    - trufflehog@3.68.4
+    - yamllint@1.35.1
   ignore:
     - linters: [ALL]
       paths: ["**/test_data/**"]

--- a/TODO.txt
+++ b/TODO.txt
@@ -11,7 +11,6 @@ Scope:
     b. Require in-order
     c. Silence on going backwards
 3. Maximum hunt size (10 MB) and relevant permissions
-4. Popup mode (overlay)
-5. limit webpack bundle size
-6. Load existing hunt state when populating options.html
-7. Make the badge text be the currentProgress num
+4. limit webpack bundle size
+5. Load existing hunt state when populating options.html
+6. Make the badge text be the currentProgress num

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/TylerJang27/Scav_Hunt_Extension"
   },
-  "license": "BSD-3-Clause",
+  "license": "MIT",
   "author": "TylerJang27",
   "scripts": {
     "build": "webpack --config webpack/webpack.prod.js",

--- a/public/res/tutorial.json
+++ b/public/res/tutorial.json
@@ -1,5 +1,5 @@
 {
-  "name": "The Hunt Is On",
+  "name": "Tutorial",
   "description": "A basic scavenger hunt",
   "version": "1.0",
   "author": "Tyler Jang",

--- a/src/__tests__/integration_tests/landing_page.test.ts
+++ b/src/__tests__/integration_tests/landing_page.test.ts
@@ -77,4 +77,16 @@ test("landing page", async ({ page, extensionId }) => {
 
   // TODO(Tyler): When clicked, should it redirect in the playwright test?
   await page.getByTestId("hunt-submit-button").click();
+
+  // Once submitted, reloading the page should show the same chosen state.
+  await page.goto(`chrome-extension://${extensionId}/landing_page.html`);
+  await expect(page.getByTestId("hunt-preset-toggle")).toHaveAttribute(
+    "aria-pressed",
+    "false",
+  );
+  await expect(page.getByTestId("hunt-submit-button")).toHaveAttribute(
+    "aria-disabled",
+    "true",
+  );
+  await expect(page.getByTestId("hunt-upload-button")).toHaveText("hunt.json");
 });

--- a/src/__tests__/integration_tests/linear_hunt.test.ts
+++ b/src/__tests__/integration_tests/linear_hunt.test.ts
@@ -3,7 +3,8 @@ import { expect, test } from "src/__tests__/integration_tests/fixtures";
 
 const PATH_TO_TEST_DATA = "src/__tests__/integration_tests/test_data";
 
-// TODO(Tyler): See if we can test the alerts and clicking on the badge as well.
+// NOTE(Tyler): There does not seem to be a way to interact with the badge/alert at this time.
+// https://github.com/microsoft/playwright/issues/5593
 test("end to end test", async ({ page, extensionId }) => {
   // Navigate to the landing page, and select an upload file
   await page.goto(`chrome-extension://${extensionId}/landing_page.html`);

--- a/src/__tests__/integration_tests/nonlinear_hunt.test.ts
+++ b/src/__tests__/integration_tests/nonlinear_hunt.test.ts
@@ -56,6 +56,7 @@ test("reverse test", async ({ page, extensionId }) => {
 });
 
 // TODO(Tyler): Add testing for unusual flows.
+// trunk-ignore(eslint/playwright/no-skipped-test)
 test.skip("stress test", async ({ page, extensionId }) => {
   await page.goto(`chrome-extension://${extensionId}/landing_page.html`);
   await expect(page.locator("body")).toContainText("Begin A Hunt");

--- a/src/__tests__/integration_tests/nonlinear_hunt.test.ts
+++ b/src/__tests__/integration_tests/nonlinear_hunt.test.ts
@@ -55,8 +55,8 @@ test("reverse test", async ({ page, extensionId }) => {
   await expect(page.locator("body")).toContainText("The Hunt Is On: 1");
 });
 
-test("stress test", async ({ page, extensionId }) => {
+// TODO(Tyler): Add testing for unusual flows.
+test.skip("stress test", async ({ page, extensionId }) => {
   await page.goto(`chrome-extension://${extensionId}/landing_page.html`);
   await expect(page.locator("body")).toContainText("Begin A Hunt");
-  // TODO: TYLER ANY OTHER UNUSUAL USER BEHAVIOR YOU CAN THINK OF
 });

--- a/src/__tests__/integration_tests/stress_hunt.test.ts
+++ b/src/__tests__/integration_tests/stress_hunt.test.ts
@@ -3,7 +3,6 @@ import { expect, test } from "src/__tests__/integration_tests/fixtures";
 
 const PATH_TO_TEST_DATA = "src/__tests__/integration_tests/test_data";
 
-// TODO(Tyler): See if we can test the alerts and clicking on the badge as well.
 test("stress test", async ({ page, extensionId }) => {
   // Navigate to the landing page, and select an upload file
   await page.goto(`chrome-extension://${extensionId}/landing_page.html`);

--- a/src/__tests__/unit_tests/choose_hunt.test.ts
+++ b/src/__tests__/unit_tests/choose_hunt.test.ts
@@ -37,7 +37,7 @@ it("Save config", () => {
 
   getLastErrorMock.mockReturnValue(undefined);
 
-  saveConfigAndLaunch(presetHunt, "Preset", { displayMode: "Tab" }, "Foods",);
+  saveConfigAndLaunch(presetHunt, "Preset", { displayMode: "Tab" }, "Foods");
   expect(saveMock).toHaveBeenCalledTimes(1);
   expect(createTabMock).toHaveBeenCalledTimes(1);
   expect(createTabMock).toHaveBeenCalledWith("beginning.html");

--- a/src/__tests__/unit_tests/choose_hunt.test.ts
+++ b/src/__tests__/unit_tests/choose_hunt.test.ts
@@ -29,6 +29,7 @@ it("Save config", () => {
       userConfig: {
         displayMode: "Tab",
       },
+      sourceInfo: "Foods",
     });
     // Provide preset hunt, with no progress made yet
     callback();
@@ -36,7 +37,7 @@ it("Save config", () => {
 
   getLastErrorMock.mockReturnValue(undefined);
 
-  saveConfigAndLaunch(presetHunt, "Preset", { displayMode: "Tab" });
+  saveConfigAndLaunch(presetHunt, "Preset", { displayMode: "Tab" }, "Foods",);
   expect(saveMock).toHaveBeenCalledTimes(1);
   expect(createTabMock).toHaveBeenCalledTimes(1);
   expect(createTabMock).toHaveBeenCalledWith("beginning.html");
@@ -53,6 +54,7 @@ it("Reset config", () => {
       maxProgress: null,
       currentProgress: null,
       userConfig: null,
+      sourceInfo: null,
     });
     // Provide sample hunt, with no progress made yet
     callback();

--- a/src/__tests__/unit_tests/match_url.test.ts
+++ b/src/__tests__/unit_tests/match_url.test.ts
@@ -6,7 +6,7 @@ import {
 } from "src/__tests__/unit_tests/create_hunt_config";
 import { loadHuntProgress } from "src/content_script";
 
-// TODO: Add additional test coverage for loading an old corrupted hunt once we have multiple config versions.
+// TODO(Tyler): Add additional test coverage for loading an old corrupted hunt once we have multiple config versions.
 // New extension versions should be compatible with older hunts when possible.
 
 jest.mock("src/providers/alert");

--- a/src/background.ts
+++ b/src/background.ts
@@ -59,7 +59,6 @@ export const setupMessageListener = () =>
         setBadgeText("");
         return;
       } else {
-        // TODO(Tyler): Make this be change the hunt background to be red
         // Invalid
         setBadgeText("");
         return;

--- a/src/components/landing_page/ChooseHunt.tsx
+++ b/src/components/landing_page/ChooseHunt.tsx
@@ -45,8 +45,8 @@ interface SourceFormType {
   uploadedError?: Error;
 }
 
-// TODO: TYLER MOVE THIS LOGIC TO THEME
-// TODO: TYLER HANDLE DARK VS LIGHT MODE
+// TODO(Tyler): Move this logic to themes.
+// TODO(Tyler): Handle light vs. dark mode.
 const ToggleButton = styled(MuiToggleButton)({
   "&.Mui-selected, &.Mui-selected:hover": {
     color: "white",
@@ -128,7 +128,6 @@ export const saveConfigAndLaunch = (
         logger.error("Error saving initial progress", error);
       } else {
         // Popup beginnining of hunt
-        logger.info("Saved initial progress", progress); // TODO: TYLER REMOVE PROGRESS FROM LOG
         await createTab("beginning.html");
       }
     })();
@@ -141,7 +140,7 @@ interface HuntPreset {
 }
 
 const getPresetOptions = () => {
-  // TODO: TYLER POPULATE THIS WITH MORE DEFAULTS
+  // TODO(Tyler): Add more defaults to the hunt presets.
   const presetHuntOptions = new Array<HuntPreset>();
   presetHuntOptions.push({ name: "Tutorial", filename: "tutorial.json" });
   presetHuntOptions.push({ name: "Foods", filename: "foods.json" });
@@ -155,7 +154,6 @@ const getPresetOptions = () => {
 export const ChooseHunt = () => {
   const presetHuntOptions = getPresetOptions();
 
-  // TODO: TYLER USE PRESET USEEFFECT TO GET THE CURRENT CONFIGURATION
   // Persistent state
   const initialPreset = "Tutorial";
   const [sourceFormState, setSourceFormState] = useState<SourceFormType>({
@@ -222,7 +220,6 @@ export const ChooseHunt = () => {
 
   // Upload state
   const validateAndSetUploadedConfig = (huntConfig: any, fileName: string) => {
-    logger.info("Validating hunt config"); // TODO: REMOVE
     try {
       const parsedConfig = ParseConfig(huntConfig);
       setSourceFormState({
@@ -350,7 +347,6 @@ export const ChooseHunt = () => {
                   _: React.MouseEvent<HTMLElement>,
                   nextView: string,
                 ) => {
-                  logger.info("Source type being set", nextView); // TODO: REMOVE
                   if (nextView !== null && nextView !== undefined) {
                     setSourceFormState({
                       ...sourceFormState,

--- a/src/components/landing_page/ChooseHunt.tsx
+++ b/src/components/landing_page/ChooseHunt.tsx
@@ -30,7 +30,12 @@ import { loadStorageValues, saveStorageValues } from "src/providers/storage";
 import { createTab } from "src/providers/tabs";
 import { EMPTY_OR_INVALID_HUNT } from "src/types/errors";
 import { HuntConfig, SAMPLE_DIR } from "src/types/hunt_config";
-import { HuntSource, Progress, SomeProgress, UserConfig } from "src/types/progress";
+import {
+  HuntSource,
+  Progress,
+  SomeProgress,
+  UserConfig,
+} from "src/types/progress";
 import { ParseConfig } from "src/utils/parse";
 
 interface SourceFormType {
@@ -215,7 +220,7 @@ export const ChooseHunt = () => {
             setResetable(false);
           }
           if (userConfig) {
-            setSettingsState({ userConfig.displayMode });
+            setUserConfigState(userConfig);
           }
         } catch (err) {
           logger.warn(EMPTY_OR_INVALID_HUNT);
@@ -331,15 +336,30 @@ export const ChooseHunt = () => {
           const presetJson = await fetchFromPresets(presetPath);
           const presetName = getPresetOptions({ filename: presetPath })[0].name;
           const parsedConfig = ParseConfig(presetJson);
-          saveConfigAndLaunch(parsedConfig, sourceType, userConfigState, presetName);
+          saveConfigAndLaunch(
+            parsedConfig,
+            sourceType,
+            userConfigState,
+            presetName,
+          );
         } else if (sourceType == "URL" && sourceURL) {
           // trunk-ignore(eslint/@typescript-eslint/no-unsafe-assignment)
           const fetchedJson = await fetchFromUrl(sourceURL);
           const parsedConfig = ParseConfig(fetchedJson);
-          saveConfigAndLaunch(parsedConfig, sourceType, userConfigState, sourceURL);
+          saveConfigAndLaunch(
+            parsedConfig,
+            sourceType,
+            userConfigState,
+            sourceURL,
+          );
         } else if (sourceType == "Upload" && uploadedConfig) {
           // huntConfig will have already been parsed
-          saveConfigAndLaunch(uploadedConfig, sourceType, userConfigState, sourceFormState.fileName ?? "");
+          saveConfigAndLaunch(
+            uploadedConfig,
+            sourceType,
+            userConfigState,
+            sourceFormState.fileName ?? "",
+          );
         } else {
           logger.warn(
             "Error: unknown condition reached when submitting. Please refresh the page.",

--- a/src/content_script.ts
+++ b/src/content_script.ts
@@ -67,7 +67,6 @@ const sendClueFound = (maxProgress: number, solvedClue: ClueConfig) => {
     });
   };
 
-  console.log("tyler doing the popup thing"); // todo: remove
   saveStorageValues(
     {
       maxProgress:

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -1,5 +1,5 @@
 // These are the settings used for production logging
-// TODO: Make logs namespaced for easier debugging
+// TODO(Tyler): Make logs namespaced for easier debugging
 
 export const logger = {
   // trunk-ignore(eslint/@typescript-eslint/no-unused-vars)

--- a/src/overlay.tsx
+++ b/src/overlay.tsx
@@ -59,7 +59,7 @@ const loadSolvedClueFromStorage = (
   );
 };
 
-// TODO: TYLER ADD TESTING FOR OVERLAY MODE
+// NOTE(Tyler): Overlay popup testing is not supported via playwright: https://github.com/microsoft/playwright/issues/5593
 const Overlay = () => {
   const [huntName, setHuntName] = useState<string>("Scavenger Hunt");
   const [encrypted, setEncrypted] = useState<boolean>(false);

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -60,7 +60,6 @@ const Popup = () => {
   const [error, setError] = useState<string | undefined>();
   const [backgroundURL, setBackgroundURL] = useState<string>("");
 
-  // TODO: TYLER MAKE SURE EVERYWHERE ELSE HAS THE USE EFFECT IT NEEDS
   useEffect(
     () =>
       loadSolvedClueFromStorage(

--- a/src/providers/__mocks__/chrome.ts
+++ b/src/providers/__mocks__/chrome.ts
@@ -10,7 +10,7 @@ logger.warn("Using mocked chrome library");
  * These are incomplete mocks of the chrome library, used for local development.
  * Override the returned values as appropriate in order to suit development needs.
  *
- * TODO: Read in provided values from a locally untracked json/data file, otherwise use defaults.
+ * TODO(Tyler): Read in provided values from a locally untracked json/data file, otherwise use defaults.
  */
 
 const storageGetter = (items: string | string[], callback: Function) => {

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -9,6 +9,7 @@ export const storageKeys = [
   "sourceType",
   "huntConfig",
   "userConfig",
+  "sourceInfo",
 ] as const;
 export type StorageKeys = (typeof storageKeys)[number];
 

--- a/src/types/hunt_config.ts
+++ b/src/types/hunt_config.ts
@@ -24,7 +24,6 @@ export interface ClueConfig {
 }
 
 // TODO: OTHER OPTIONS, SUCH AS REQUIRE IN-ORDER, SHOW_PROGRESS
-// TODO: SHOULD THE HTML OPTION INCLUDE A NOTICE?
 export interface HuntOptions {
   silent: boolean;
 }

--- a/src/types/progress.ts
+++ b/src/types/progress.ts
@@ -16,16 +16,11 @@ export interface Progress {
   currentProgress: number;
   // since 1.1.0
   userConfig: UserConfig;
+  // since 1.1.0
+  sourceInfo: string;
 }
 
-export interface SomeProgress {
-  sourceType?: HuntSource;
-  huntConfig?: HuntConfig;
-  maxProgress?: number;
-  currentProgress?: number;
-  // since 1.1.0
-  userConfig?: UserConfig;
-}
+export type SomeProgress = Partial<Progress>;
 
 export interface SolvedOptions {
   encrypted: boolean;


### PR DESCRIPTION
Stacked on #21. Finally adds the logic to initialize the ChooseHunt section to the saved state, including with some additional metadata attached. Choose File will not be submittable on refresh, but that's fine. The name is still included for additional information. Adds one test case to handle the refresh and load saved state.