### PR TITLE
Introduce progress bar for linear hunts

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -6,8 +6,6 @@ Development:
 
 Scope:
 1. Replace HTML support with markdown and sanitize
-2. Audit hunt settings and if we want more options
-    a. Progress bar
-    b. Silence on going backwards
-3. limit webpack bundle size
-4. Make the badge text be the currentProgress num
+2. limit webpack bundle size
+3. Make the badge text be the currentProgress num?
+4. More default hunts

--- a/src/components/encode/CreateClueModal.tsx
+++ b/src/components/encode/CreateClueModal.tsx
@@ -230,6 +230,7 @@ export const CreateClueModal = (props: CreateClueModalProps) => {
         huntName={props.huntName || "Preview"}
         encrypted={false}
         clue={createdClue}
+        numClues={undefined}
         previewOnly={true}
         backgroundURL={
           props.huntBackground || getURL("graphics/background.png")

--- a/src/components/reusable/CluePage.tsx
+++ b/src/components/reusable/CluePage.tsx
@@ -1,5 +1,6 @@
 import { ThemeProvider } from "@emotion/react";
 import {
+  Box,
   Button,
   Card,
   CardContent,
@@ -11,6 +12,9 @@ import {
   Tooltip,
   Typography,
 } from "@mui/material";
+import LinearProgress, {
+  linearProgressClasses,
+} from "@mui/material/LinearProgress";
 import React, { useEffect, useState } from "react";
 import { BackgroundWrapper } from "src/components/reusable/BackgroundWrapper";
 import { PageHeaderAndSubtitle } from "src/components/reusable/PageHeaderAndSubtitle";
@@ -22,10 +26,19 @@ import { nonNull } from "src/utils/helpers";
 
 import { Footer, OverlayFooter } from "./Footer";
 
+const BorderLinearProgress = styled(LinearProgress)(() => ({
+  height: 8,
+  borderRadius: 4,
+  [`& .${linearProgressClasses.bar}`]: {
+    borderRadius: 4,
+  },
+}));
+
 export interface CluePageProps {
   huntName: string;
   encrypted: boolean;
   clue: ClueConfig;
+  numClues?: number;
   error?: string;
   previewOnly?: boolean;
   backgroundURL: string;
@@ -94,6 +107,15 @@ export const CluePage = (props: CluePageProps) => {
     <>
       <BackgroundWrapper backgroundURL={backgroundURL} scale={previewScale}>
         <ThemeProvider theme={theme}>
+          {props.numClues !== undefined && (
+            <Box sx={{ width: "100%" }}>
+              <BorderLinearProgress
+                variant="determinate"
+                value={(id * 100.0) / props.numClues}
+                color="secondary"
+              />
+            </Box>
+          )}
           <Container
             maxWidth="sm"
             sx={{ mt: 3, "&::after": { flex: "auto" }, ...previewStyles }}
@@ -236,6 +258,15 @@ export const ClueOverlay = (props: CluePageProps) => {
     <>
       <BackgroundWrapper backgroundURL={backgroundURL}>
         <ThemeProvider theme={theme}>
+          {props.numClues !== undefined && (
+            <Box sx={{ width: "100%" }}>
+              <BorderLinearProgress
+                variant="determinate"
+                value={(id * 100.0) / props.numClues}
+                color="secondary"
+              />
+            </Box>
+          )}
           <Container maxWidth="sm" sx={{ mt: 1, "&::after": { flex: "auto" } }}>
             <Grid
               container

--- a/src/overlay.tsx
+++ b/src/overlay.tsx
@@ -16,6 +16,7 @@ const DEFAULT_LOADING_CLUE = {
 
 const loadSolvedClueFromStorage = (
   huntNameCallback: (item: string) => void,
+  numCluesCallback: (item: number | undefined) => void,
   encryptedCallback: (item: boolean) => void,
   huntBackgroundCallback: (item: string) => void,
   clueCallback: (item: ClueConfig) => void,
@@ -29,7 +30,7 @@ const loadSolvedClueFromStorage = (
         errorCallback(EMPTY_OR_INVALID_HUNT);
         return;
       }
-      const { name, encrypted, background, beginning, clues } =
+      const { name, encrypted, background, beginning, clues, options } =
         items.huntConfig;
 
       if (items.currentProgress === 0) {
@@ -52,6 +53,7 @@ const loadSolvedClueFromStorage = (
       );
 
       huntNameCallback(name);
+      numCluesCallback(options.inOrder ? clues.length : undefined);
       encryptedCallback(encrypted);
       huntBackgroundCallback(background);
       clueCallback(decryptedClue);
@@ -62,6 +64,7 @@ const loadSolvedClueFromStorage = (
 // NOTE(Tyler): Overlay popup testing is not supported via playwright: https://github.com/microsoft/playwright/issues/5593
 const Overlay = () => {
   const [huntName, setHuntName] = useState<string>("Scavenger Hunt");
+  const [numClues, setNumClues] = useState<number | undefined>();
   const [encrypted, setEncrypted] = useState<boolean>(false);
   const [decryptedClue, setDecryptedClue] =
     useState<ClueConfig>(DEFAULT_LOADING_CLUE);
@@ -73,6 +76,7 @@ const Overlay = () => {
     () =>
       loadSolvedClueFromStorage(
         setHuntName,
+        setNumClues,
         setEncrypted,
         setBackgroundURL,
         setDecryptedClue,
@@ -86,6 +90,7 @@ const Overlay = () => {
       huntName={huntName}
       encrypted={encrypted}
       clue={decryptedClue}
+      numClues={numClues}
       error={error}
       previewOnly={true}
       backgroundURL={backgroundURL}

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -19,6 +19,7 @@ const DEFAULT_LOADING_CLUE = {
 
 const loadSolvedClueFromStorage = (
   huntNameCallback: (item: string) => void,
+  numCluesCallback: (item: number | undefined) => void,
   encryptedCallback: (item: boolean) => void,
   huntBackgroundCallback: (item: string) => void,
   clueCallback: (item: ClueConfig) => void,
@@ -37,7 +38,7 @@ const loadSolvedClueFromStorage = (
         return;
       }
 
-      const { name, encrypted, background, clues } = items.huntConfig;
+      const { name, encrypted, background, clues, options } = items.huntConfig;
       const decryptedClue = DecryptClue(
         clues[items.currentProgress! - 1],
         encrypted,
@@ -45,6 +46,7 @@ const loadSolvedClueFromStorage = (
       );
 
       huntNameCallback(name);
+      numCluesCallback(options.inOrder ? clues.length : undefined);
       encryptedCallback(encrypted);
       huntBackgroundCallback(background);
       clueCallback(decryptedClue);
@@ -54,6 +56,7 @@ const loadSolvedClueFromStorage = (
 
 const Popup = () => {
   const [huntName, setHuntName] = useState<string>("Scavenger Hunt");
+  const [numClues, setNumClues] = useState<number | undefined>();
   const [encrypted, setEncrypted] = useState<boolean>(false);
   const [decryptedClue, setDecryptedClue] =
     useState<ClueConfig>(DEFAULT_LOADING_CLUE);
@@ -64,6 +67,7 @@ const Popup = () => {
     () =>
       loadSolvedClueFromStorage(
         setHuntName,
+        setNumClues,
         setEncrypted,
         setBackgroundURL,
         setDecryptedClue,
@@ -76,6 +80,7 @@ const Popup = () => {
       huntName={huntName}
       encrypted={encrypted}
       clue={decryptedClue}
+      numClues={numClues}
       error={error}
       backgroundURL={backgroundURL}
     />


### PR DESCRIPTION
For linear hunts only, the popup and the overlay will include a progress bar indicating the current clue progress / number of clues. Undefined is used to indicate that this is the "beginning" clue or that this is a nonlinear hunt.

We may want to make this configurable in the future, but I think it's a better user experience to be the default.

![image](https://github.com/TylerJang27/Scav_Hunt_Extension/assets/42743566/d94949e1-31c1-4728-a54d-459321e43817)
